### PR TITLE
Sanitize datetime UDTs to standard Calcite types in planner and add execution tests

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -9,19 +9,29 @@ import static org.opensearch.sql.monitor.profile.MetricName.ANALYZE;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
 import org.opensearch.sql.api.parser.NamedArgRewriter;
 import org.opensearch.sql.api.parser.UnifiedQueryParser;
 import org.opensearch.sql.ast.tree.UnresolvedPlan;
 import org.opensearch.sql.calcite.CalciteRelNodeVisitor;
+import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
+import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.executor.QueryType;
 
@@ -60,12 +70,72 @@ public class UnifiedQueryPlanner {
    */
   public RelNode plan(String query) {
     try {
-      return context.measure(ANALYZE, () -> strategy.plan(query));
+      return context.measure(ANALYZE, () -> sanitizeExprUdtTypes(strategy.plan(query)));
     } catch (SyntaxCheckException | UnsupportedOperationException e) {
       throw e;
     } catch (Exception e) {
       throw new IllegalStateException("Failed to plan query", e);
     }
+  }
+
+  /**
+   * Rewrites expression UDT types in Rex nodes to standard Calcite SQL datetime types for unified
+   * API consumers.
+   */
+  private RelNode sanitizeExprUdtTypes(RelNode plan) {
+    RexBuilder rexBuilder = context.getPlanContext().rexBuilder;
+    RexShuttle shuttle =
+        new RexShuttle() {
+          @Override
+          public RexNode visitInputRef(RexInputRef inputRef) {
+            RexInputRef rewritten = (RexInputRef) super.visitInputRef(inputRef);
+            if (!isDatetimeUdt(rewritten.getType())) {
+              return rewritten;
+            }
+
+            SqlTypeName sqlType =
+                UserDefinedFunctionUtils.convertRelDataTypeToSqlTypeName(rewritten.getType());
+            RelDataType targetType =
+                rexBuilder
+                    .getTypeFactory()
+                    .createTypeWithNullability(
+                        rexBuilder.getTypeFactory().createSqlType(sqlType),
+                        rewritten.getType().isNullable());
+            return rexBuilder.makeInputRef(targetType, rewritten.getIndex());
+          }
+
+          @Override
+          public RexNode visitCall(RexCall call) {
+            RexCall rewritten = (RexCall) super.visitCall(call);
+
+            if (!(rewritten.getOperator() instanceof SqlUserDefinedFunction)
+                || !isDatetimeUdt(rewritten.getType())) {
+              return rewritten;
+            }
+
+            SqlTypeName sqlType =
+                UserDefinedFunctionUtils.convertRelDataTypeToSqlTypeName(rewritten.getType());
+            RelDataType targetType =
+                rexBuilder
+                    .getTypeFactory()
+                    .createTypeWithNullability(
+                        rexBuilder.getTypeFactory().createSqlType(sqlType),
+                        rewritten.getType().isNullable());
+            return rexBuilder.makeCall(targetType, rewritten.getOperator(), rewritten.getOperands());
+          }
+
+          private boolean isDatetimeUdt(RelDataType type) {
+            if (!(type instanceof AbstractExprRelDataType<?>)) {
+              return false;
+            }
+            SqlTypeName sqlType = UserDefinedFunctionUtils.convertRelDataTypeToSqlTypeName(type);
+            return sqlType == SqlTypeName.DATE
+                || sqlType == SqlTypeName.TIME
+                || sqlType == SqlTypeName.TIMESTAMP;
+          }
+        };
+
+    return plan.accept(shuttle);
   }
 
   /** Strategy interface for language-specific planning logic. */

--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerTest.java
@@ -5,14 +5,26 @@
 
 package org.opensearch.sql.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Map;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelVisitor;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.impl.AbstractSchema;
 import org.junit.Test;
+import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
 import org.opensearch.sql.common.antlr.SyntaxCheckException;
 import org.opensearch.sql.executor.QueryType;
 
@@ -104,6 +116,132 @@ public class UnifiedQueryPlannerTest extends UnifiedQueryTestBase {
     RelNode plan =
         planner.plan("source = catalog1.employees | lookup employees id | eval f = abs(id)");
     assertNotNull("Plan should be created with multiple catalogs", plan);
+  }
+
+  @Test
+  public void testDateTimeUdfsProduceOnlyStandardCalciteTypesInPlanAndRexNodes() {
+    RelNode plan =
+        planner.plan(
+            "source = catalog.employees"
+                + " | eval d = DATE('2020-06-01'), t = TIME('09:30:00'),"
+                + " ts = TIMESTAMP('2020-06-01 09:30:00')"
+                + " | where d > DATE('2020-05-01') and t > TIME('09:00:00')"
+                + " and ts > TIMESTAMP('2020-06-01 09:00:00')"
+                + " | fields d, t, ts");
+
+    assertEquals(
+        SqlTypeName.DATE, plan.getRowType().getFieldList().get(0).getType().getSqlTypeName());
+    assertEquals(
+        SqlTypeName.TIME, plan.getRowType().getFieldList().get(1).getType().getSqlTypeName());
+    assertEquals(
+        SqlTypeName.TIMESTAMP, plan.getRowType().getFieldList().get(2).getType().getSqlTypeName());
+
+    assertPlanHasNoExprUdtTypes(plan);
+  }
+
+  @Test
+  public void testMultipleDatetimeUdfsHaveNoExprUdtInPlan() {
+    RelNode plan =
+        planner.plan(
+            "source = catalog.employees"
+                + " | eval d = DATE('2020-06-01'),"
+                + " t = TIME('09:30:00'),"
+                + " ts = TIMESTAMP('2020-06-01 09:30:00'),"
+                + " md = MAKEDATE(2020, 15),"
+                + " s2d = STR_TO_DATE('01,5,2013', '%d,%m,%Y'),"
+                + " ad = ADDDATE(DATE('2020-06-01'), 1),"
+                + " sd = SUBDATE(DATE('2020-06-02'), 1),"
+                + " cd = CURRENT_DATE(),"
+                + " ud = UTC_DATE(),"
+                + " st = SYSDATE()"
+                + " | fields d, t, ts, md, s2d, ad, sd, cd, ud, st");
+
+    assertPlanHasNoExprUdtTypes(plan);
+  }
+
+  @Test
+  public void testDatetimeUdfSignaturesSanitizedForBroadDatetimeFunctionSet() {
+    RelNode plan =
+        planner.plan(
+            "source = catalog.employees"
+                + " | eval d = DATE('2020-06-01'),"
+                + " t = TIME('09:30:00'),"
+                + " ts = TIMESTAMP('2020-06-01 09:30:00'),"
+                + " at = ADDTIME(TIME('09:30:00'), TIME('00:10:00')),"
+                + " st2 = SUBTIME(TIME('09:30:00'), TIME('00:10:00')),"
+                + " ad = ADDDATE(DATE('2020-06-01'), 1),"
+                + " sd = SUBDATE(DATE('2020-06-02'), 1),"
+                + " da = DATE_ADD(TIMESTAMP('2020-06-01 09:30:00'), INTERVAL 1 DAY),"
+                + " ds = DATE_SUB(TIMESTAMP('2020-06-02 09:30:00'), INTERVAL 1 DAY),"
+                + " n = NOW(),"
+                + " ct = CURRENT_TIME(),"
+                + " cd = CURRENT_DATE(),"
+                + " cz = CONVERT_TZ('2020-06-01 10:00:00', '+00:00', '+08:00'),"
+                + " ld = LAST_DAY('2020-06-15'),"
+                + " fd = FROM_DAYS(738000),"
+                + " md = MAKEDATE(2020, 15),"
+                + " mt = MAKETIME(10, 20, 30),"
+                + " s2d = STR_TO_DATE('01,5,2013', '%d,%m,%Y'),"
+                + " sd2 = SYSDATE(),"
+                + " s2t = SEC_TO_TIME(3600)"
+                + " | fields d, t, ts, at, st2, ad, sd, da, ds, n, ct, cd, cz, ld, fd, md, mt, s2d, sd2, s2t");
+
+    assertPlanHasNoExprUdtTypes(plan);
+  }
+
+
+  private void assertPlanHasNoExprUdtTypes(RelNode plan) {
+    RexVisitorImpl<Void> rexTypeVerifier =
+        new RexVisitorImpl<>(true) {
+          @Override
+          public Void visitCall(RexCall call) {
+            assertNoExprUdt(call.getType());
+            return super.visitCall(call);
+          }
+
+          @Override
+          public Void visitInputRef(RexInputRef inputRef) {
+            assertNoExprUdt(inputRef.getType());
+            return super.visitInputRef(inputRef);
+          }
+
+          @Override
+          public Void visitLiteral(RexLiteral literal) {
+            assertNoExprUdt(literal.getType());
+            return super.visitLiteral(literal);
+          }
+        };
+
+    new RelVisitor() {
+      @Override
+      public void visit(RelNode node, int ordinal, RelNode parent) {
+        assertNoExprUdt(node.getRowType());
+        for (RexNode childExpr : node.getChildExps()) {
+          childExpr.accept(rexTypeVerifier);
+        }
+        super.visit(node, ordinal, parent);
+      }
+    }.go(plan);
+  }
+
+  private void assertNoExprUdt(RelDataType type) {
+    assertFalse(type instanceof AbstractExprRelDataType);
+
+    for (RelDataTypeField field : type.getFieldList()) {
+      assertNoExprUdt(field.getType());
+    }
+
+    if (type.getComponentType() != null) {
+      assertNoExprUdt(type.getComponentType());
+    }
+
+    if (type.getKeyType() != null) {
+      assertNoExprUdt(type.getKeyType());
+    }
+
+    if (type.getValueType() != null) {
+      assertNoExprUdt(type.getValueType());
+    }
   }
 
   @Test(expected = UnsupportedOperationException.class)

--- a/api/src/test/java/org/opensearch/sql/api/compiler/UnifiedQueryCompilerTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/compiler/UnifiedQueryCompilerTest.java
@@ -9,14 +9,36 @@ import static java.sql.Types.BIGINT;
 import static java.sql.Types.INTEGER;
 import static java.sql.Types.VARCHAR;
 
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.DataContext;
+import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.RelShuttle;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.Statistic;
+import org.apache.calcite.schema.Statistics;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.opensearch.sql.api.ResultSetAssertion;
+import org.opensearch.sql.api.UnifiedQueryContext;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
+import org.opensearch.sql.api.UnifiedQueryPlanner;
 import org.opensearch.sql.api.UnifiedQueryTestBase;
 
 public class UnifiedQueryCompilerTest extends UnifiedQueryTestBase implements ResultSetAssertion {
@@ -54,6 +76,172 @@ public class UnifiedQueryCompilerTest extends UnifiedQueryTestBase implements Re
       verify(resultSet)
           .expectSchema(col("count()", BIGINT), col("department", VARCHAR))
           .expectData(row(2L, "Engineering"), row(1L, "Sales"), row(1L, "Marketing"));
+    }
+  }
+
+  @Test
+  public void testDateComparisonInWhereClause() throws Exception {
+    AbstractSchema schema =
+        new AbstractSchema() {
+          @Override
+          protected Map<String, Table> getTableMap() {
+            return Map.of(
+                "employees",
+                SimpleTable.builder()
+                    .col("id", SqlTypeName.INTEGER)
+                    .col("date_hired", SqlTypeName.DATE)
+                    .row(new Object[] {1, Date.valueOf("2020-03-15")})
+                    .row(new Object[] {2, Date.valueOf("2020-06-15")})
+                    .build());
+          }
+        };
+
+    try (UnifiedQueryContext dateContext =
+            UnifiedQueryContext.builder()
+                .language(queryType())
+                .catalog(DEFAULT_CATALOG, schema)
+                .build()) {
+      UnifiedQueryPlanner datePlanner = new UnifiedQueryPlanner(dateContext);
+      UnifiedQueryCompiler dateCompiler = new UnifiedQueryCompiler(dateContext);
+
+      RelNode plan =
+          datePlanner.plan(
+              "source = catalog.employees | where date_hired > DATE('2020-06-01')");
+      try (PreparedStatement statement = dateCompiler.compile(plan)) {
+        ResultSet resultSet = statement.executeQuery();
+
+        verify(resultSet)
+            .expectSchema(col("id", INTEGER), col("date_hired", java.sql.Types.DATE))
+            .expectData(row(2, Date.valueOf("2020-06-15")));
+      }
+    }
+  }
+
+
+  @Test
+  public void testDateTimeComparisonsInWhereClause() throws Exception {
+    AbstractSchema schema =
+        new AbstractSchema() {
+          @Override
+          protected Map<String, Table> getTableMap() {
+            return Map.of(
+                "events",
+                SimpleTable.builder()
+                    .col("id", SqlTypeName.INTEGER)
+                    .col("d", SqlTypeName.DATE)
+                    .col("t", SqlTypeName.TIME)
+                    .col("ts", SqlTypeName.TIMESTAMP)
+                    .row(
+                        new Object[] {
+                          1,
+                          Date.valueOf("2020-06-01"),
+                          Time.valueOf("09:00:00"),
+                          Timestamp.valueOf("2020-06-01 09:00:00")
+                        })
+                    .row(
+                        new Object[] {
+                          2,
+                          Date.valueOf("2020-06-15"),
+                          Time.valueOf("10:30:00"),
+                          Timestamp.valueOf("2020-06-15 10:30:00")
+                        })
+                    .build());
+          }
+        };
+
+    try (UnifiedQueryContext dateTimeContext =
+            UnifiedQueryContext.builder()
+                .language(queryType())
+                .catalog(DEFAULT_CATALOG, schema)
+                .build()) {
+      UnifiedQueryPlanner dateTimePlanner = new UnifiedQueryPlanner(dateTimeContext);
+      UnifiedQueryCompiler dateTimeCompiler = new UnifiedQueryCompiler(dateTimeContext);
+
+      RelNode plan =
+          dateTimePlanner.plan(
+              "source = catalog.events"
+                  + " | where d > DATE('2020-06-01')"
+                  + " and t > TIME('09:30:00')"
+                  + " and ts > TIMESTAMP('2020-06-01 09:30:00')"
+                  + " | fields id");
+      try (PreparedStatement statement = dateTimeCompiler.compile(plan)) {
+        ResultSet resultSet = statement.executeQuery();
+
+        verify(resultSet).expectSchema(col("id", INTEGER)).expectData(row(2));
+      }
+    }
+  }
+
+
+  @Test
+  public void testUdtDateColumnCanBePlannedAndExecutedWithoutTypeException() throws Exception {
+    AbstractSchema schema =
+        new AbstractSchema() {
+          @Override
+          protected Map<String, Table> getTableMap() {
+            ScannableTable udtDateTable =
+                new ScannableTable() {
+                  @Override
+                  public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+                    return typeFactory
+                        .builder()
+                        .add("id", typeFactory.createSqlType(SqlTypeName.INTEGER))
+                        .add("d", OpenSearchTypeFactory.TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE, true))
+                        .build();
+                  }
+
+                  @Override
+                  public org.apache.calcite.linq4j.Enumerable<Object[]> scan(DataContext root) {
+                    return Linq4j.asEnumerable(
+                        List.of(
+                            new Object[] {1, "2020-06-01"},
+                            new Object[] {2, "2020-06-15"}));
+                  }
+
+                  @Override
+                  public Statistic getStatistic() {
+                    return Statistics.UNKNOWN;
+                  }
+
+                  @Override
+                  public Schema.TableType getJdbcTableType() {
+                    return Schema.TableType.TABLE;
+                  }
+
+                  @Override
+                  public boolean isRolledUp(String column) {
+                    return false;
+                  }
+
+                  @Override
+                  public boolean rolledUpColumnValidInsideAgg(
+                      String column,
+                      SqlCall call,
+                      SqlNode parent,
+                      org.apache.calcite.config.CalciteConnectionConfig config) {
+                    return false;
+                  }
+                };
+
+            return Map.of("events", udtDateTable);
+          }
+        };
+
+    try (UnifiedQueryContext udtContext =
+            UnifiedQueryContext.builder()
+                .language(queryType())
+                .catalog(DEFAULT_CATALOG, schema)
+                .build()) {
+      UnifiedQueryPlanner udtPlanner = new UnifiedQueryPlanner(udtContext);
+      UnifiedQueryCompiler udtCompiler = new UnifiedQueryCompiler(udtContext);
+
+      RelNode plan =
+          udtPlanner.plan(
+              "source = catalog.events | eval d2 = DATE(d) | where d2 > DATE('2020-06-01') | fields id");
+      try (PreparedStatement statement = udtCompiler.compile(plan)) {
+        ResultSet resultSet = statement.executeQuery();
+        verify(resultSet).expectSchema(col("id", INTEGER)).expectData(row(2));
+      }
     }
   }
 

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprDateValue.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprDateValue.java
@@ -78,6 +78,11 @@ public class ExprDateValue extends AbstractExprValue {
   }
 
   @Override
+  public Object valueForCalcite() {
+    return Math.toIntExact(date.toEpochDay());
+  }
+
+  @Override
   public String toString() {
     return String.format("DATE '%s'", value());
   }

--- a/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java
+++ b/core/src/main/java/org/opensearch/sql/data/model/ExprValueUtils.java
@@ -173,10 +173,19 @@ public class ExprValueUtils {
   public static ExprValue fromObjectValue(Object o, ExprType type) {
     switch (type) {
       case TIMESTAMP:
+        if (o instanceof Long l) {
+          return timestampValue(Instant.ofEpochMilli(l));
+        }
         return new ExprTimestampValue((String) o);
       case DATE:
+        if (o instanceof Integer i) {
+          return dateValue(LocalDate.ofEpochDay(i.longValue()));
+        }
         return new ExprDateValue((String) o);
       case TIME:
+        if (o instanceof Integer i) {
+          return timeValue(LocalTime.ofNanoOfDay(i.longValue() * 1_000_000L));
+        }
         return new ExprTimeValue((String) o);
       default:
         return fromObjectValue(o);

--- a/core/src/test/java/org/opensearch/sql/data/model/ExprValueUtilsTest.java
+++ b/core/src/test/java/org/opensearch/sql/data/model/ExprValueUtilsTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -242,6 +243,25 @@ public class ExprValueUtilsTest {
     assertEquals(
         new ExprTimestampValue("2012-07-07 01:01:01"),
         ExprValueUtils.fromObjectValue("2012-07-07 01:01:01", TIMESTAMP));
+  }
+
+
+  @Test
+  public void constructDateValueFromCalciteInternalInteger() {
+    ExprValue value = ExprValueUtils.fromObjectValue(20297, DATE);
+    assertEquals(LocalDate.of(2025, 7, 28), value.dateValue());
+  }
+
+  @Test
+  public void constructTimeValueFromCalciteInternalInteger() {
+    ExprValue value = ExprValueUtils.fromObjectValue(34_200_000, TIME);
+    assertEquals(LocalTime.of(9, 30), value.timeValue());
+  }
+
+  @Test
+  public void constructTimestampValueFromCalciteInternalLong() {
+    ExprValue value = ExprValueUtils.fromObjectValue(1_717_233_000_000L, TIMESTAMP);
+    assertEquals(Instant.ofEpochMilli(1_717_233_000_000L), value.timestampValue());
   }
 
   @Test


### PR DESCRIPTION
### Motivation
- Ensure expression-level user-defined datetime types are converted to standard Calcite SQL datetime types so unified API consumers (planner, compiler, JDBC) do not observe `AbstractExprRelDataType` instances in plans or Rex nodes.
- Prevent runtime/type-mismatch issues when compiling and executing plans that originate from Expr UDT-backed data or datetime UDFs. 

### Description
- Update `UnifiedQueryPlanner.plan` to call a new `sanitizeExprUdtTypes` method that rewrites Rex nodes to use standard Calcite `DATE`, `TIME`, or `TIMESTAMP` types for datetime UDTs.
- Implement the sanitizer as a `RexShuttle` that rewrites `RexInputRef` and `RexCall` nodes when the type is an `AbstractExprRelDataType` representing a date/time/timestamp, using `UserDefinedFunctionUtils.convertRelDataTypeToSqlTypeName` and `RexBuilder` to create nullable target types.
- Add multiple unit tests in `UnifiedQueryPlannerTest` asserting row types and all Rex nodes contain only standard Calcite datetime types for many datetime UDFs and expression combinations.
- Extend `UnifiedQueryCompilerTest` with tests that exercise date/time comparisons, handling of UDT-backed table columns, and end-to-end planning/compilation/execution over date/time values.
- Add `valueForCalcite` implementation in `ExprDateValue` to return an epoch-day integer to support Calcite execution over date values.

### Testing
- Executed `UnifiedQueryPlannerTest` which includes new assertions verifying no `AbstractExprRelDataType` instances remain in plan row types or Rex nodes, and the test suite succeeded.
- Executed `UnifiedQueryCompilerTest` which includes new integration tests for date/time comparisons and a UDT-backed table execution path, and the test suite succeeded.
- Ran existing planner/compiler unit tests to validate regressions and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de84f8b10c83299a82a82780c7a8c2)