### PR TITLE
feat(api): Add post-analysis datetime UDT normalization for unified q…

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
+++ b/api/src/main/java/org/opensearch/sql/api/UnifiedQueryPlanner.java
@@ -60,7 +60,15 @@ public class UnifiedQueryPlanner {
    */
   public RelNode plan(String query) {
     try {
-      return context.measure(ANALYZE, () -> strategy.plan(query));
+      return context.measure(
+          ANALYZE,
+          () -> {
+            RelNode plan = strategy.plan(query);
+            for (var shuttle : context.getLangSpec().postAnalysisRules()) {
+              plan = plan.accept(shuttle);
+            }
+            return plan;
+          });
     } catch (SyntaxCheckException | UnsupportedOperationException e) {
       throw e;
     } catch (Exception e) {

--- a/api/src/main/java/org/opensearch/sql/api/spec/LanguageSpec.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/LanguageSpec.java
@@ -7,6 +7,7 @@ package org.opensearch.sql.api.spec;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -17,8 +18,8 @@ import org.apache.calcite.sql.validate.SqlValidator;
 
 /**
  * Language specification defining the dialect the engine accepts. Provides parser configuration,
- * validator configuration, and composable {@link LanguageExtension}s that contribute operators and
- * post-parse rewrite rules.
+ * validator configuration, and composable {@link LanguageExtension}s that contribute operators,
+ * post-parse rewrite rules, and post-analysis rewrite rules.
  *
  * <p>Implementations define a complete language surface — for example, {@link UnifiedSqlSpec}
  * provides ANSI and extended SQL modes. A future PPL spec would implement this same interface once
@@ -27,8 +28,9 @@ import org.apache.calcite.sql.validate.SqlValidator;
 public interface LanguageSpec {
 
   /**
-   * A composable language extension that contributes operators and post-parse rewrite rules. All
-   * methods have defaults so extensions only override what they need.
+   * A composable language extension that contributes operators, post-parse rewrite rules, and
+   * post-analysis rewrite rules. All methods have defaults so extensions only override what they
+   * need.
    */
   interface LanguageExtension {
 
@@ -47,6 +49,14 @@ public interface LanguageSpec {
     default List<SqlVisitor<SqlNode>> postParseRules() {
       return List.of();
     }
+
+    /**
+     * RelNode rewrite rules applied after analysis and before execution. Each rule transforms the
+     * logical plan tree. Rules within a single extension are applied in list order.
+     */
+    default List<RelShuttle> postAnalysisRules() {
+      return List.of();
+    }
   }
 
   /**
@@ -62,9 +72,9 @@ public interface LanguageSpec {
   SqlValidator.Config validatorConfig();
 
   /**
-   * Language extensions registered with this spec. Each extension contributes operators and
-   * post-parse rewrite rules that are composed by {@link #operatorTable()} and {@link
-   * #postParseRules()}.
+   * Language extensions registered with this spec. Each extension contributes operators, post-parse
+   * rewrite rules, and post-analysis rewrite rules composed by {@link #operatorTable()}, {@link
+   * #postParseRules()}, and {@link #postAnalysisRules()}.
    */
   List<LanguageExtension> extensions();
 
@@ -85,5 +95,13 @@ public interface LanguageSpec {
    */
   default List<SqlVisitor<SqlNode>> postParseRules() {
     return extensions().stream().flatMap(ext -> ext.postParseRules().stream()).toList();
+  }
+
+  /**
+   * All post-analysis RelNode rewrite rules from registered extensions, flattened in registration
+   * order. Applied to the logical plan after analysis and before execution.
+   */
+  default List<RelShuttle> postAnalysisRules() {
+    return extensions().stream().flatMap(ext -> ext.postAnalysisRules().stream()).toList();
   }
 }

--- a/api/src/main/java/org/opensearch/sql/api/spec/UnifiedPplSpec.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/UnifiedPplSpec.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.validate.SqlValidator;
+import org.opensearch.sql.api.spec.datetime.DatetimeExtension;
 
 /**
  * PPL language specification.
@@ -37,6 +38,6 @@ public class UnifiedPplSpec implements LanguageSpec {
 
   @Override
   public List<LanguageExtension> extensions() {
-    return List.of();
+    return List.of(new DatetimeExtension());
   }
 }

--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeExtension.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeExtension.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.datetime;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.calcite.rel.RelShuttle;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.sql.api.spec.LanguageSpec.LanguageExtension;
+import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
+import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT;
+
+/** Datetime language extension that normalizes UDT types and casts output for wire-format. */
+public class DatetimeExtension implements LanguageExtension {
+
+  @Override
+  public List<RelShuttle> postAnalysisRules() {
+    return List.of(DatetimeUdtNormalizeRule.INSTANCE, DatetimeOutputCastRule.INSTANCE);
+  }
+
+  /** Maps datetime UDT types to their standard Calcite equivalents. */
+  @Getter
+  @RequiredArgsConstructor
+  enum UdtMapping {
+    DATE(ExprUDT.EXPR_DATE, SqlTypeName.DATE),
+    TIME(ExprUDT.EXPR_TIME, SqlTypeName.TIME),
+    TIMESTAMP(ExprUDT.EXPR_TIMESTAMP, SqlTypeName.TIMESTAMP);
+
+    private final ExprUDT udtType;
+    private final SqlTypeName stdType;
+
+    /** Matches a UDT RelDataType to its mapping, or empty if not a datetime UDT. */
+    static Optional<UdtMapping> fromUdtType(RelDataType type) {
+      if (!(type instanceof AbstractExprRelDataType<?> e)) {
+        return Optional.empty();
+      }
+      ExprUDT udt = e.getUdt();
+      return Arrays.stream(values()).filter(u -> u.udtType == udt).findFirst();
+    }
+
+    /** Returns true if the given SqlTypeName is a standard datetime type. */
+    static boolean isDatetimeType(SqlTypeName typeName) {
+      return Arrays.stream(values()).anyMatch(u -> u.stdType == typeName);
+    }
+  }
+}

--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeOutputCastRule.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeOutputCastRule.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.datetime;
+
+import static org.opensearch.sql.api.spec.datetime.DatetimeExtension.UdtMapping.isDatetimeType;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/** Wraps the root output with CAST(datetime → VARCHAR) for PPL wire-format compatibility. */
+class DatetimeOutputCastRule extends RelHomogeneousShuttle {
+
+  static final DatetimeOutputCastRule INSTANCE = new DatetimeOutputCastRule();
+
+  @Override
+  public RelNode visit(RelNode other) {
+    List<RelDataTypeField> fields = other.getRowType().getFieldList();
+    if (fields.stream().noneMatch(f -> isDatetimeType(f.getType().getSqlTypeName()))) {
+      return other;
+    }
+
+    RexBuilder rexBuilder = other.getCluster().getRexBuilder();
+    List<RexNode> projects = new ArrayList<>(fields.size());
+    List<String> names = new ArrayList<>(fields.size());
+
+    for (RelDataTypeField field : fields) {
+      RexNode ref = rexBuilder.makeInputRef(other, field.getIndex());
+      if (isDatetimeType(field.getType().getSqlTypeName())) {
+        projects.add(castToVarchar(rexBuilder, ref, field.getType()));
+      } else {
+        projects.add(ref);
+      }
+      names.add(field.getName());
+    }
+    return LogicalProject.create(other, List.of(), projects, names);
+  }
+
+  private static RexNode castToVarchar(RexBuilder rexBuilder, RexNode expr, RelDataType fieldType) {
+    RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+    RelDataType varcharType =
+        typeFactory.createTypeWithNullability(
+            typeFactory.createSqlType(SqlTypeName.VARCHAR), fieldType.isNullable());
+    return rexBuilder.makeCast(varcharType, expr);
+  }
+}

--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdtNormalizeRule.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdtNormalizeRule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.datetime;
+
+import java.util.Optional;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.opensearch.sql.api.spec.datetime.DatetimeExtension.UdtMapping;
+
+/**
+ * Temporary patch that rewrites datetime UDT return types on RexCall nodes to standard Calcite
+ * types.
+ */
+class DatetimeUdtNormalizeRule extends RelHomogeneousShuttle {
+
+  static final DatetimeUdtNormalizeRule INSTANCE = new DatetimeUdtNormalizeRule();
+
+  @Override
+  public RelNode visit(RelNode other) {
+    RelNode visited = super.visit(other);
+    RexBuilder rexBuilder = visited.getCluster().getRexBuilder();
+    RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+    return visited.accept(
+        new RexShuttle() {
+          @Override
+          public RexNode visitCall(RexCall call) {
+            call = (RexCall) super.visitCall(call);
+            Optional<UdtMapping> mapping = UdtMapping.fromUdtType(call.getType());
+            if (mapping.isEmpty()) {
+              return call;
+            }
+
+            RelDataType stdType =
+                typeFactory.createTypeWithNullability(
+                    typeFactory.createSqlType(mapping.get().getStdType()),
+                    call.getType().isNullable());
+            return call.clone(stdType, call.getOperands());
+          }
+        });
+  }
+}

--- a/api/src/test/java/org/opensearch/sql/api/spec/datetime/DatetimeExtensionTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/spec/datetime/DatetimeExtensionTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.datetime;
+
+import static java.sql.Types.VARCHAR;
+import static org.apache.calcite.sql.type.SqlTypeName.DATE;
+import static org.apache.calcite.sql.type.SqlTypeName.INTEGER;
+import static org.apache.calcite.sql.type.SqlTypeName.TIME;
+import static org.apache.calcite.sql.type.SqlTypeName.TIMESTAMP;
+import static org.junit.Assert.assertFalse;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Map;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.schema.Table;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.sql.api.ResultSetAssertion;
+import org.opensearch.sql.api.UnifiedQueryContext;
+import org.opensearch.sql.api.UnifiedQueryTestBase;
+import org.opensearch.sql.api.compiler.UnifiedQueryCompiler;
+import org.opensearch.sql.calcite.type.AbstractExprRelDataType;
+import org.opensearch.sql.executor.QueryType;
+
+public class DatetimeExtensionTest extends UnifiedQueryTestBase implements ResultSetAssertion {
+
+  private UnifiedQueryCompiler compiler;
+
+  @Override
+  protected UnifiedQueryContext.Builder contextBuilder() {
+    return UnifiedQueryContext.builder()
+        .language(QueryType.PPL)
+        .catalog(
+            DEFAULT_CATALOG,
+            new AbstractSchema() {
+              @Override
+              protected Map<String, Table> getTableMap() {
+                return Map.of("events", createEventsTable());
+              }
+            });
+  }
+
+  @Before
+  public void setUp() {
+    super.setUp();
+    compiler = new UnifiedQueryCompiler(context);
+  }
+
+  private Table createEventsTable() {
+    return SimpleTable.builder()
+        .col("id", INTEGER)
+        .col("name", org.apache.calcite.sql.type.SqlTypeName.VARCHAR)
+        .col("hire_date", DATE)
+        .col("start_time", TIME)
+        .col("created_at", TIMESTAMP)
+        .row(new Object[] {1, "Alice", 19738, 43200000, 1705305600000L})
+        .row(new Object[] {2, "Bob", 19894, 50400000, 1718841600000L})
+        .build();
+  }
+
+  @Test
+  public void testUdfResultNormalizedAndCastToVarchar() {
+    var result =
+        givenQuery("source = catalog.events | eval d = DATE(name) | fields d")
+            .assertPlan(
+                """
+                LogicalProject(d=[CAST($0):VARCHAR])
+                  LogicalProject(d=[DATE($1)])
+                    LogicalTableScan(table=[[catalog, events]])
+                """);
+    assertNoUdt(result.plan());
+  }
+
+  @Test
+  public void testNestedUdfCallsNormalized() {
+    var result =
+        givenQuery("source = catalog.events | eval d = DATEDIFF(DATE(name), DATE(name)) | fields d")
+            .assertPlan(
+                """
+                LogicalProject(d=[DATEDIFF(DATE($1), DATE($1))])
+                  LogicalTableScan(table=[[catalog, events]])
+                """);
+    assertNoUdt(result.plan());
+  }
+
+  @Test
+  public void testDateLiteralCastToVarchar() {
+    var result =
+        givenQuery("source = catalog.events | eval d = DATE('2024-01-01') | fields d")
+            .assertPlan(
+                """
+                LogicalProject(d=[CAST($0):VARCHAR])
+                  LogicalProject(d=[DATE('2024-01-01':VARCHAR)])
+                    LogicalTableScan(table=[[catalog, events]])
+                """);
+    assertNoUdt(result.plan());
+  }
+
+  @Test
+  public void testFilterWithTimestampLiteral() {
+    var result =
+        givenQuery(
+                """
+                source = catalog.events | where created_at > "2024-01-01T00:00:00Z" | fields id\
+                """)
+            .assertPlan(
+                """
+                LogicalProject(id=[$0])
+                  LogicalFilter(condition=[>($4, TIMESTAMP('2024-01-01T00:00:00Z':VARCHAR))])
+                    LogicalTableScan(table=[[catalog, events]])
+                """);
+    assertNoUdt(result.plan());
+  }
+
+  @Test
+  public void testComparisonWithDatetimeUdf() {
+    var result =
+        givenQuery("source = catalog.events | where created_at < DATE(name) | fields id")
+            .assertPlan(
+                """
+                LogicalProject(id=[$0])
+                  LogicalFilter(condition=[<($4, TIMESTAMP(DATE($1)))])
+                    LogicalTableScan(table=[[catalog, events]])
+                """);
+    assertNoUdt(result.plan());
+  }
+
+  @Test
+  public void testAllStandardDatetimeTypesCastToVarchar() {
+    var result =
+        givenQuery("source = catalog.events | fields hire_date, start_time, created_at")
+            .assertPlan(
+                """
+                LogicalProject(hire_date=[CAST($0):VARCHAR NOT NULL], start_time=[CAST($1):VARCHAR NOT NULL], created_at=[CAST($2):VARCHAR NOT NULL])
+                  LogicalProject(hire_date=[$2], start_time=[$3], created_at=[$4])
+                    LogicalTableScan(table=[[catalog, events]])
+                """);
+    assertNoUdt(result.plan());
+  }
+
+  @Test
+  public void testNonDatetimeFieldsNotWrapped() {
+    var result =
+        givenQuery("source = catalog.events | fields id, name")
+            .assertPlan(
+                """
+                LogicalProject(id=[$0], name=[$1])
+                  LogicalTableScan(table=[[catalog, events]])
+                """);
+    assertNoUdt(result.plan());
+  }
+
+  @Test
+  public void testOutputCastCanCompileAndExecute() throws Exception {
+    RelNode plan =
+        planner.plan("source = catalog.events | fields hire_date, start_time, created_at");
+    try (PreparedStatement statement = compiler.compile(plan)) {
+      ResultSet resultSet = statement.executeQuery();
+      verify(resultSet)
+          .expectSchema(
+              col("hire_date", VARCHAR), col("start_time", VARCHAR), col("created_at", VARCHAR))
+          .expectData(
+              row("2024-01-16", "12:00:00", "2024-01-15 08:00:00"),
+              row("2024-06-20", "14:00:00", "2024-06-20 00:00:00"));
+    }
+  }
+
+  private static void assertNoUdt(RelNode plan) {
+    plan.accept(
+        new RelHomogeneousShuttle() {
+          @Override
+          public RelNode visit(RelNode other) {
+            RelNode visited = super.visit(other);
+            visited.accept(
+                new RexShuttle() {
+                  @Override
+                  public RexNode visitCall(RexCall call) {
+                    assertFalse(
+                        "Found UDT type in RexCall: " + call,
+                        call.getType() instanceof AbstractExprRelDataType<?>);
+                    return super.visitCall(call);
+                  }
+                });
+            return visited;
+          }
+        });
+  }
+}


### PR DESCRIPTION
…uery API

Add PostAnalysisRule framework to LanguageSpec and two rules registered via DatetimeUdtExtension in UnifiedPplSpec:

1. DatetimeUdtNormalizeRule rewrites datetime UDT return types (EXPR_DATE/TIME/TIMESTAMP) on RexCall nodes to standard Calcite DATE/TIME/TIMESTAMP types. The function call is preserved — only the declared return type changes.

2. DatetimeOutputProjectRule adds a final LogicalProject that casts standard datetime output columns to VARCHAR, aligning with PPL's wire-format contract (ISO string representation).

Both rules run as postAnalysisRules after the planning strategy produces the RelNode, applied uniformly to both SQL and PPL paths.

No changes to core/ module — UDF definitions and implementors are untouched. The mismatch between rewritten signatures and UDF implementations is a known limitation addressed separately.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
