### PR TITLE
Feature/ppl udt compilation adapter

### DIFF
--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeExtension.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeExtension.java
@@ -25,6 +25,11 @@ public class DatetimeExtension implements LanguageExtension {
     return List.of(DatetimeUdtNormalizeRule.INSTANCE, DatetimeOutputCastRule.INSTANCE);
   }
 
+  @Override
+  public List<RelShuttle> preCompilationRules() {
+    return List.of(DatetimeUdfCompilationAdapterRule.INSTANCE);
+  }
+
   /** Maps datetime UDT types to their standard Calcite equivalents. */
   @Getter
   @RequiredArgsConstructor

--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdfCompilationAdapterRule.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdfCompilationAdapterRule.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.sql.api.spec.datetime;
+
+import static org.opensearch.sql.api.spec.datetime.DatetimeExtension.UdtMapping.isDatetimeType;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.validate.SqlUserDefinedFunction;
+
+/**
+ * Adapts datetime UDF calls for Enumerable compilation. PPL UDF implementors expect String
+ * input/output, but after normalization the plan uses standard DATE/TIME/TIMESTAMP types
+ * (int/long). This rule inserts CASTs to bridge the mismatch:
+ *
+ * <pre>
+ *   Before: LAST_DAY($2:DATE) : DATE
+ *   After:  CAST(LAST_DAY(CAST($2 AS VARCHAR)):VARCHAR AS DATE)
+ * </pre>
+ */
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+class DatetimeUdfCompilationAdapterRule extends RelHomogeneousShuttle {
+
+  static final DatetimeUdfCompilationAdapterRule INSTANCE = new DatetimeUdfCompilationAdapterRule();
+
+  @Override
+  public RelNode visit(RelNode other) {
+    RelNode visited = super.visit(other);
+    RexBuilder rexBuilder = visited.getCluster().getRexBuilder();
+    RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
+    return visited.accept(
+        new RexShuttle() {
+          @Override
+          public RexNode visitCall(RexCall call) {
+            call = (RexCall) super.visitCall(call);
+            if (!(call.getOperator() instanceof SqlUserDefinedFunction)) {
+              return call;
+            }
+
+            // Adapt operands: CAST(datetime_operand AS VARCHAR) for UDF implementor
+            List<RexNode> adapted = new ArrayList<>(call.getOperands().size());
+            boolean operandsChanged = false;
+            for (RexNode operand : call.getOperands()) {
+              if (isDatetimeType(operand.getType().getSqlTypeName())) {
+                RelDataType varcharType =
+                    typeFactory.createTypeWithNullability(
+                        typeFactory.createSqlType(SqlTypeName.VARCHAR),
+                        operand.getType().isNullable());
+                adapted.add(rexBuilder.makeCast(varcharType, operand));
+                operandsChanged = true;
+              } else {
+                adapted.add(operand);
+              }
+            }
+
+            // Adapt result: if return type is datetime, wrap call with VARCHAR return + CAST back
+            if (isDatetimeType(call.getType().getSqlTypeName())) {
+              RelDataType declaredType = call.getType();
+              RelDataType varcharType =
+                  typeFactory.createTypeWithNullability(
+                      typeFactory.createSqlType(SqlTypeName.VARCHAR), declaredType.isNullable());
+              RexCall varcharCall =
+                  call.clone(varcharType, operandsChanged ? adapted : call.getOperands());
+              return rexBuilder.makeCast(declaredType, varcharCall);
+            }
+
+            return operandsChanged ? call.clone(call.getType(), adapted) : call;
+          }
+        });
+  }
+}

--- a/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdtNormalizeRule.java
+++ b/api/src/main/java/org/opensearch/sql/api/spec/datetime/DatetimeUdtNormalizeRule.java
@@ -5,15 +5,21 @@
 
 package org.opensearch.sql.api.spec.datetime;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.calcite.rel.RelHomogeneousShuttle;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -30,10 +36,82 @@ class DatetimeUdtNormalizeRule extends RelHomogeneousShuttle {
 
   @Override
   public RelNode visit(RelNode other) {
-    RelNode visited = super.visit(other);
-    RexBuilder rexBuilder = visited.getCluster().getRexBuilder();
+    // Visit children first
+    List<RelNode> newInputs = new ArrayList<>();
+    boolean childChanged = false;
+    for (RelNode input : other.getInputs()) {
+      RelNode newInput = input.accept(this);
+      newInputs.add(newInput);
+      if (newInput != input) {
+        childChanged = true;
+      }
+    }
+
+    // Rebuild current node if children changed
+    RelNode current = other;
+    if (childChanged) {
+      if (current instanceof LogicalAggregate agg) {
+        // Aggregate needs AggregateCall types rebuilt
+        RelNode newInput = newInputs.get(0);
+        List<AggregateCall> newAggCalls =
+            agg.getAggCallList().stream()
+                .map(
+                    call ->
+                        AggregateCall.create(
+                            call.getAggregation(),
+                            call.isDistinct(),
+                            call.isApproximate(),
+                            call.ignoreNulls(),
+                            call.rexList,
+                            call.getArgList(),
+                            call.filterArg,
+                            call.distinctKeys,
+                            call.collation,
+                            agg.getGroupCount(),
+                            newInput,
+                            null,
+                            call.getName()))
+                .toList();
+        current =
+            agg.copy(
+                agg.getTraitSet(), newInput, agg.getGroupSet(), agg.getGroupSets(), newAggCalls);
+      } else if (current instanceof LogicalProject proj) {
+        // Project needs RexInputRef types refreshed from new child
+        RelNode newInput = newInputs.get(0);
+        RexBuilder rexBuilder = proj.getCluster().getRexBuilder();
+        List<RexNode> newProjects =
+            proj.getProjects().stream()
+                .map(
+                    expr ->
+                        expr.accept(
+                            new RexShuttle() {
+                              @Override
+                              public RexNode visitInputRef(RexInputRef ref) {
+                                RelDataType newType =
+                                    newInput
+                                        .getRowType()
+                                        .getFieldList()
+                                        .get(ref.getIndex())
+                                        .getType();
+                                if (!newType.equals(ref.getType())) {
+                                  return rexBuilder.makeInputRef(newType, ref.getIndex());
+                                }
+                                return ref;
+                              }
+                            }))
+                .toList();
+        current =
+            LogicalProject.create(
+                newInput, proj.getHints(), newProjects, proj.getRowType().getFieldNames());
+      } else {
+        current = current.copy(current.getTraitSet(), newInputs);
+      }
+    }
+
+    // Apply RexShuttle to normalize UDT types in this node's expressions
+    RexBuilder rexBuilder = current.getCluster().getRexBuilder();
     RelDataTypeFactory typeFactory = rexBuilder.getTypeFactory();
-    return visited.accept(
+    return current.accept(
         new RexShuttle() {
           @Override
           public RexNode visitCall(RexCall call) {
@@ -43,7 +121,6 @@ class DatetimeUdtNormalizeRule extends RelHomogeneousShuttle {
               return call;
             }
 
-            // Normalize UDT return type to standard Calcite DATE/TIME/TIMESTAMP
             UdtMapping m = mapping.get();
             SqlTypeName stdTypeName = m.getStdType();
             RelDataType baseType =

--- a/api/src/test/java/org/opensearch/sql/api/spec/datetime/DatetimeExtensionTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/spec/datetime/DatetimeExtensionTest.java
@@ -71,114 +71,97 @@ public class DatetimeExtensionTest extends UnifiedQueryTestBase implements Resul
   }
 
   @Test
-  public void testUdfResultNormalizedAndCastToVarchar() {
+  public void testUdfOnLiteralsNormalizedAndExecutable() throws Exception {
     var plan =
         givenQuery(
                 """
                 source = catalog.events \
-                | eval d = DATE(name), t = TIME(name), ts = TIMESTAMP(name) \
+                | eval d = DATE('2024-01-01'), t = TIME('12:30:00'), ts = TIMESTAMP('2024-01-01 12:30:00') \
                 | fields d, t, ts\
                 """)
             .assertPlan(
                 """
                 LogicalProject(d=[CAST($0):VARCHAR], t=[CAST($1):VARCHAR], ts=[CAST($2):VARCHAR])
-                  LogicalProject(d=[DATE($1)], t=[TIME($1)], ts=[TIMESTAMP($1)])
+                  LogicalProject(d=[DATE('2024-01-01':VARCHAR)], t=[TIME('12:30:00':VARCHAR)], ts=[TIMESTAMP('2024-01-01 12:30:00':VARCHAR)])
                     LogicalTableScan(table=[[catalog, events]])
                 """)
             .plan();
     assertCallType(plan, "DATE", DATE);
     assertCallType(plan, "TIME", TIME, 9);
     assertCallType(plan, "TIMESTAMP", TIMESTAMP, 9);
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs)
+          .expectSchema(
+              col("d", java.sql.Types.VARCHAR),
+              col("t", java.sql.Types.VARCHAR),
+              col("ts", java.sql.Types.VARCHAR))
+          .expectData(
+              row("2024-01-01", "12:30:00", "2024-01-01 12:30:00"),
+              row("2024-01-01", "12:30:00", "2024-01-01 12:30:00"));
+    }
   }
 
   @Test
-  public void testNestedUdfCallsNormalized() {
+  public void testNestedUdfCallsExecutable() throws Exception {
     var plan =
-        givenQuery("source = catalog.events | eval d = DATEDIFF(DATE(name), DATE(name)) | fields d")
+        givenQuery(
+                """
+                source = catalog.events \
+                | eval d = DATEDIFF(DATE('2025-01-01'), DATE('2024-01-01')) \
+                | fields d\
+                """)
             .assertPlan(
                 """
-                LogicalProject(d=[DATEDIFF(DATE($1), DATE($1))])
+                LogicalProject(d=[DATEDIFF(DATE('2025-01-01':VARCHAR), DATE('2024-01-01':VARCHAR))])
                   LogicalTableScan(table=[[catalog, events]])
                 """)
             .plan();
     assertCallType(plan, "DATE", DATE);
     assertCallType(plan, "DATEDIFF", BIGINT);
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs).expectSchema(col("d", java.sql.Types.BIGINT)).expectData(row(366L), row(366L));
+    }
   }
 
   @Test
-  public void testDateLiteralCastToVarchar() {
-    var plan =
-        givenQuery("source = catalog.events | eval d = DATE('2024-01-01') | fields d")
-            .assertPlan(
-                """
-                LogicalProject(d=[CAST($0):VARCHAR])
-                  LogicalProject(d=[DATE('2024-01-01':VARCHAR)])
-                    LogicalTableScan(table=[[catalog, events]])
-                """)
-            .plan();
-    assertCallType(plan, "DATE", DATE);
-  }
-
-  @Test
-  public void testFilterWithTimestampLiteral() {
+  public void testFilterWithTimestampUdf() throws Exception {
     var plan =
         givenQuery(
                 """
-                source = catalog.events | where created_at > "2024-01-01T00:00:00Z" | fields id\
+                source = catalog.events \
+                | where created_at < TIMESTAMP('2024-06-01 00:00:00') \
+                | fields id\
                 """)
             .assertPlan(
                 """
                 LogicalProject(id=[$0])
-                  LogicalFilter(condition=[>($4, TIMESTAMP('2024-01-01T00:00:00Z':VARCHAR))])
+                  LogicalFilter(condition=[<($4, TIMESTAMP('2024-06-01 00:00:00':VARCHAR))])
                     LogicalTableScan(table=[[catalog, events]])
                 """)
             .plan();
     assertCallType(plan, "TIMESTAMP", TIMESTAMP, 9);
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs).expectSchema(col("id", java.sql.Types.INTEGER)).expectData(row(1));
+    }
   }
 
   @Test
-  public void testComparisonWithDatetimeUdf() {
+  public void testStandardDatetimeFieldsCastToVarchar() throws Exception {
     var plan =
-        givenQuery("source = catalog.events | where created_at < DATE(name) | fields id")
+        givenQuery("source = catalog.events | fields hire_date, start_time, created_at")
             .assertPlan(
                 """
-                LogicalProject(id=[$0])
-                  LogicalFilter(condition=[<($4, TIMESTAMP(DATE($1)))])
+                LogicalProject(hire_date=[CAST($0):VARCHAR NOT NULL], start_time=[CAST($1):VARCHAR NOT NULL], created_at=[CAST($2):VARCHAR NOT NULL])
+                  LogicalProject(hire_date=[$2], start_time=[$3], created_at=[$4])
                     LogicalTableScan(table=[[catalog, events]])
                 """)
             .plan();
-    assertCallType(plan, "DATE", DATE);
-    assertCallType(plan, "TIMESTAMP", TIMESTAMP, 9);
-  }
-
-  @Test
-  public void testAllStandardDatetimeTypesCastToVarchar() {
-    givenQuery("source = catalog.events | fields hire_date, start_time, created_at")
-        .assertPlan(
-            """
-            LogicalProject(hire_date=[CAST($0):VARCHAR NOT NULL], start_time=[CAST($1):VARCHAR NOT NULL], created_at=[CAST($2):VARCHAR NOT NULL])
-              LogicalProject(hire_date=[$2], start_time=[$3], created_at=[$4])
-                LogicalTableScan(table=[[catalog, events]])
-            """);
-  }
-
-  @Test
-  public void testNonDatetimeFieldsNotWrapped() {
-    givenQuery("source = catalog.events | fields id, name")
-        .assertPlan(
-            """
-            LogicalProject(id=[$0], name=[$1])
-              LogicalTableScan(table=[[catalog, events]])
-            """);
-  }
-
-  @Test
-  public void testOutputCastCanCompileAndExecute() throws Exception {
-    RelNode plan =
-        planner.plan("source = catalog.events | fields hire_date, start_time, created_at");
-    try (PreparedStatement statement = compiler.compile(plan)) {
-      ResultSet resultSet = statement.executeQuery();
-      verify(resultSet)
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs)
           .expectSchema(
               col("hire_date", java.sql.Types.VARCHAR),
               col("start_time", java.sql.Types.VARCHAR),
@@ -186,6 +169,42 @@ public class DatetimeExtensionTest extends UnifiedQueryTestBase implements Resul
           .expectData(
               row("2024-01-16", "12:00:00", "2024-01-15 08:00:00"),
               row("2024-06-20", "14:00:00", "2024-06-20 00:00:00"));
+    }
+  }
+
+  @Test
+  public void testNonDatetimeFieldsNotWrapped() throws Exception {
+    var plan =
+        givenQuery("source = catalog.events | fields id, name")
+            .assertPlan(
+                """
+                LogicalProject(id=[$0], name=[$1])
+                  LogicalTableScan(table=[[catalog, events]])
+                """)
+            .plan();
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs)
+          .expectSchema(col("id", java.sql.Types.INTEGER), col("name", java.sql.Types.VARCHAR))
+          .expectData(row(1, "Alice"), row(2, "Bob"));
+    }
+  }
+
+  @Test
+  public void testNonDatetimeUdfUnaffected() throws Exception {
+    var plan =
+        givenQuery("source = catalog.events | eval s = CONCAT(name, ' test') | fields s")
+            .assertPlan(
+                """
+                LogicalProject(s=[CONCAT($1, ' test':VARCHAR)])
+                  LogicalTableScan(table=[[catalog, events]])
+                """)
+            .plan();
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs)
+          .expectSchema(col("s", java.sql.Types.VARCHAR))
+          .expectData(row("Alice test"), row("Bob test"));
     }
   }
 
@@ -220,6 +239,37 @@ public class DatetimeExtensionTest extends UnifiedQueryTestBase implements Resul
     if (expectedPrecision >= 0) {
       assertEquals(
           operatorName + " precision", expectedPrecision, ref.get().getType().getPrecision());
+    }
+  }
+
+  @Test
+  public void testAggMaxOnDatetimeUdf() throws Exception {
+    var plan = planner.plan("source = catalog.events | stats max(DATE('2024-01-01')) as m");
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs).expectSchema(col("m", java.sql.Types.VARCHAR)).expectData(row("2024-01-01"));
+    }
+  }
+
+  @Test
+  public void testAggGroupByDatetimeUdf() throws Exception {
+    var plan =
+        planner.plan(
+            "source = catalog.events | eval d = DATE('2024-01-01') | stats count() as c by d");
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs)
+          .expectSchema(col("c", java.sql.Types.BIGINT), col("d", java.sql.Types.VARCHAR))
+          .expectData(row(2L, "2024-01-01"));
+    }
+  }
+
+  @Test
+  public void testAggOnDatetimeColumnWorks() throws Exception {
+    var plan = planner.plan("source = catalog.events | stats max(hire_date) as m");
+    try (PreparedStatement stmt = compiler.compile(plan)) {
+      ResultSet rs = stmt.executeQuery();
+      verify(rs).expectSchema(col("m", java.sql.Types.VARCHAR)).expectData(row("2024-06-20"));
     }
   }
 }


### PR DESCRIPTION
Add preCompilationRules to LanguageSpec.LanguageExtension and register DatetimeUdfCompilationAdapterRule in DatetimeExtension. The rule inserts CAST nodes to bridge the type mismatch between normalized standard types (DATE/TIME/TIMESTAMP as int/long) and PPL UDF implementors (which expect and produce String values):

  Before: LAST_DAY($2:DATE) : DATE
  After:  CAST(LAST_DAY(CAST($2 AS VARCHAR)):VARCHAR AS DATE)

Applied only in UnifiedQueryCompiler before Enumerable code generation, so the logical plan seen by other consumers (Analytics Engine, Substrait) remains clean with standard types.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
