### PR TITLE
feat(calcite): fix visitor issues for V2 SQL AST integration

### DIFF
--- a/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
+++ b/api/src/test/java/org/opensearch/sql/api/UnifiedQueryPlannerSqlTest.java
@@ -259,4 +259,105 @@ public class UnifiedQueryPlannerSqlTest extends UnifiedQueryTestBase {
             """)
         .assertErrorMessage("Encountered");
   }
+
+  @Test
+  public void testSqlLimitOffset() {
+    givenQuery(
+            """
+            SELECT name
+            FROM catalog.employees
+            LIMIT 10 OFFSET 5\
+            """)
+        .assertPlanContains("LogicalSort(offset=[5], fetch=[10])");
+  }
+
+  @Test
+  public void testSqlAggregateWithAlias() {
+    givenQuery(
+            """
+            SELECT department, COUNT(*) AS cnt
+            FROM catalog.employees
+            GROUP BY department\
+            """)
+        .assertPlanContains("LogicalAggregate(group=[{0}]")
+        .assertPlanContains("COUNT()");
+  }
+
+  @Test
+  public void testSqlWindowFunctionWithOrderBy() {
+    givenQuery(
+            """
+            SELECT name, SUM(age) OVER (PARTITION BY department ORDER BY id) AS running_sum
+            FROM catalog.employees\
+            """)
+        .assertPlanContains("OVER")
+        .assertPlanContains("ORDER BY");
+  }
+
+  @Test
+  public void testSqlWindowRankFunction() {
+    givenQuery(
+            """
+            SELECT name, RANK() OVER (ORDER BY age DESC) AS rnk
+            FROM catalog.employees\
+            """)
+        .assertPlanContains("RANK() OVER");
+  }
+
+  @Test
+  public void testSqlWindowDistinctAggregate() {
+    givenQuery(
+            """
+            SELECT name, COUNT(DISTINCT department) OVER (PARTITION BY department) AS dist_cnt
+            FROM catalog.employees\
+            """)
+        .assertPlanContains("OVER")
+        .assertPlanContains("COUNT");
+  }
+
+  @Test
+  public void testSqlGroupByWithoutBucketNullable() {
+    givenQuery(
+            """
+            SELECT age, COUNT(*) AS cnt
+            FROM catalog.employees
+            GROUP BY age\
+            """)
+        .assertPlanContains("LogicalAggregate(group=[{0}]")
+        .assertPlanContains("COUNT()");
+  }
+
+  @Test
+  public void testSqlSelectWithAlias() {
+    givenQuery(
+            """
+            SELECT age AS employee_age, name AS employee_name
+            FROM catalog.employees\
+            """)
+        .assertPlanContains("LogicalProject")
+        .assertPlanContains("LogicalTableScan");
+  }
+
+  @Test
+  public void testSqlDerivedTableInFromClause() {
+    // SELECT ... FROM (SELECT ...) AS t — exercises visitRelationSubquery override.
+    givenQuery(
+            """
+            SELECT t.id
+            FROM (SELECT id, name FROM catalog.employees WHERE age > 30) AS t\
+            """)
+        .assertPlanContains("LogicalProject")
+        .assertPlanContains("LogicalFilter")
+        .assertPlanContains("LogicalTableScan");
+  }
+
+  @Test
+  public void testSqlSelectWithoutFromClause() {
+    // SELECT 1 — exercises visitValues dual-table case (single empty row).
+    givenQuery(
+            """
+            SELECT 1\
+            """)
+        .assertPlanContains("LogicalValues");
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRelNodeVisitor.java
@@ -132,6 +132,7 @@ import org.opensearch.sql.ast.tree.GraphLookup.Direction;
 import org.opensearch.sql.ast.tree.Head;
 import org.opensearch.sql.ast.tree.Join;
 import org.opensearch.sql.ast.tree.Kmeans;
+import org.opensearch.sql.ast.tree.Limit;
 import org.opensearch.sql.ast.tree.Lookup;
 import org.opensearch.sql.ast.tree.Lookup.OutputStrategy;
 import org.opensearch.sql.ast.tree.ML;
@@ -146,6 +147,7 @@ import org.opensearch.sql.ast.tree.Project;
 import org.opensearch.sql.ast.tree.RareTopN;
 import org.opensearch.sql.ast.tree.Regex;
 import org.opensearch.sql.ast.tree.Relation;
+import org.opensearch.sql.ast.tree.RelationSubquery;
 import org.opensearch.sql.ast.tree.Rename;
 import org.opensearch.sql.ast.tree.Replace;
 import org.opensearch.sql.ast.tree.ReplacePair;
@@ -541,6 +543,25 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
               .filter(addedFields::add)
               .forEach(field -> expandedFields.add(context.relBuilder.field(field)));
         }
+        case Alias alias -> {
+          String aliasName =
+              Strings.isNullOrEmpty(alias.getAlias()) ? alias.getName() : alias.getAlias();
+          // When an aggregate was already computed (its output name matches a current field),
+          // reference the existing field instead of re-analyzing (which would return null).
+          if (alias.getDelegated() instanceof AggregateFunction) {
+            String aggFieldName = alias.getName();
+            if (currentFields.contains(aliasName)) {
+              expandedFields.add(context.relBuilder.field(aliasName));
+            } else if (aggFieldName != null && currentFields.contains(aggFieldName)) {
+              expandedFields.add(
+                  context.relBuilder.alias(context.relBuilder.field(aggFieldName), aliasName));
+            } else {
+              expandedFields.add(rexVisitor.analyze(alias, context));
+            }
+          } else {
+            expandedFields.add(rexVisitor.analyze(alias, context));
+          }
+        }
         default ->
             throw new IllegalStateException(
                 "Unexpected expression type in project list: " + expr.getClass().getSimpleName());
@@ -760,6 +781,13 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   public RelNode visitHead(Head node, CalcitePlanContext context) {
     visitChildren(node, context);
     context.relBuilder.limit(node.getFrom(), node.getSize());
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitLimit(Limit node, CalcitePlanContext context) {
+    visitChildren(node, context);
+    context.relBuilder.limit(node.getOffset(), node.getLimit());
     return context.relBuilder.peek();
   }
 
@@ -1621,7 +1649,8 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   @Override
   public RelNode visitAggregation(Aggregation node, CalcitePlanContext context) {
     Argument.ArgumentMap statsArgs = Argument.ArgumentMap.of(node.getArgExprList());
-    Boolean bucketNullable = (Boolean) statsArgs.get(Argument.BUCKET_NULLABLE).getValue();
+    boolean bucketNullable =
+        (Boolean) statsArgs.getOrDefault(Argument.BUCKET_NULLABLE, Literal.TRUE).getValue();
     int nGroup = node.getGroupExprList().size() + (Objects.nonNull(node.getSpan()) ? 1 : 0);
     BitSet nonNullGroupMask = new BitSet(nGroup);
     if (!bucketNullable) {
@@ -1925,6 +1954,15 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
   public RelNode visitSubqueryAlias(SubqueryAlias node, CalcitePlanContext context) {
     visitChildren(node, context);
     context.relBuilder.as(node.getAlias());
+    return context.relBuilder.peek();
+  }
+
+  @Override
+  public RelNode visitRelationSubquery(RelationSubquery node, CalcitePlanContext context) {
+    // Derived table in FROM clause: SELECT ... FROM (SELECT ...) AS t
+    // Visit the inner query, then apply the alias as the relation name.
+    visitChildren(node, context);
+    context.relBuilder.as(node.getAliasAsTableName());
     return context.relBuilder.peek();
   }
 
@@ -4122,12 +4160,14 @@ public class CalciteRelNodeVisitor extends AbstractNodeVisitor<RelNode, CalciteP
 
   @Override
   public RelNode visitValues(Values values, CalcitePlanContext context) {
-    if (values.getValues() == null || values.getValues().isEmpty()) {
+    List<List<Literal>> rows = values.getValues();
+    if (rows == null || rows.isEmpty() || (rows.size() == 1 && rows.get(0).isEmpty())) {
+      // Single empty row (dual table) = SELECT without FROM. Provide a 0-column relation
+      // so subsequent Project can evaluate constant expressions.
       context.relBuilder.values(context.relBuilder.getTypeFactory().builder().build());
       return context.relBuilder.peek();
-    } else {
-      throw new CalciteUnsupportedException("Explicit values node is unsupported in Calcite");
     }
+    throw new CalciteUnsupportedException("Inline VALUES with literal rows is unsupported");
   }
 
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -42,6 +42,7 @@ import org.apache.calcite.util.TimeString;
 import org.apache.calcite.util.TimestampString;
 import org.apache.logging.log4j.util.Strings;
 import org.opensearch.sql.ast.AbstractNodeVisitor;
+import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.ast.expression.Alias;
 import org.opensearch.sql.ast.expression.And;
 import org.opensearch.sql.ast.expression.Between;
@@ -563,15 +564,32 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
 
   @Override
   public RexNode visitWindowFunction(WindowFunction node, CalcitePlanContext context) {
-    Function windowFunction = (Function) node.getFunction();
-    List<RexNode> arguments =
-        windowFunction.getFuncArgs().stream().map(arg -> analyze(arg, context)).toList();
+    String funcName;
+    List<RexNode> arguments;
+    final boolean isDistinct;
+    if (node.getFunction() instanceof AggregateFunction aggFunc) {
+      funcName = aggFunc.getFuncName();
+      isDistinct = Boolean.TRUE.equals(aggFunc.getDistinct());
+      List<UnresolvedExpression> argExprs = new java.util.ArrayList<>();
+      if (aggFunc.getField() != null) {
+        argExprs.add(aggFunc.getField());
+      }
+      argExprs.addAll(aggFunc.getArgList());
+      arguments = argExprs.stream().map(arg -> analyze(arg, context)).toList();
+    } else {
+      Function windowFunction = (Function) node.getFunction();
+      funcName = windowFunction.getFuncName();
+      isDistinct = false;
+      arguments = windowFunction.getFuncArgs().stream().map(arg -> analyze(arg, context)).toList();
+    }
     List<RexNode> partitions =
         node.getPartitionByList().stream()
             .map(arg -> analyze(arg, context))
             .map(this::extractRexNodeFromAlias)
             .toList();
-    return BuiltinFunctionName.ofWindowFunction(windowFunction.getFuncName())
+    List<RexNode> orderKeys =
+        PlanUtils.translateOrderKeys(node.getSortList(), expr -> analyze(expr, context), context);
+    return BuiltinFunctionName.ofWindowFunction(funcName)
         .map(
             functionName -> {
               RexNode field = arguments.isEmpty() ? null : arguments.getFirst();
@@ -579,6 +597,18 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
                   (arguments.isEmpty() || arguments.size() == 1)
                       ? Collections.emptyList()
                       : arguments.subList(1, arguments.size());
+              // Pure window functions (ROW_NUMBER, RANK, DENSE_RANK) are not registered
+              // in aggFunctionRegistry, so skip validation for them.
+              if (BuiltinFunctionName.isPureWindowFunction(functionName)) {
+                return PlanUtils.makeOver(
+                    context,
+                    functionName,
+                    field,
+                    args,
+                    partitions,
+                    orderKeys,
+                    node.getWindowFrame());
+              }
               List<RexNode> nodes =
                   PPLFuncImpTable.INSTANCE.validateAggFunctionSignature(
                       functionName, field, args, context.rexBuilder);
@@ -586,24 +616,24 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
                   ? PlanUtils.makeOver(
                       context,
                       functionName,
+                      isDistinct,
                       nodes.getFirst(),
                       nodes.size() <= 1 ? Collections.emptyList() : nodes.subList(1, nodes.size()),
                       partitions,
-                      List.of(),
+                      orderKeys,
                       node.getWindowFrame())
                   : PlanUtils.makeOver(
                       context,
                       functionName,
+                      isDistinct,
                       field,
                       args,
                       partitions,
-                      List.of(),
+                      orderKeys,
                       node.getWindowFrame());
             })
         .orElseThrow(
-            () ->
-                new UnsupportedOperationException(
-                    "Unexpected window function: " + windowFunction.getFuncName()));
+            () -> new UnsupportedOperationException("Unexpected window function: " + funcName));
   }
 
   /** extract the expression of Alias from a node */

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/PlanUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/PlanUtils.java
@@ -69,6 +69,7 @@ import org.opensearch.sql.ast.AbstractNodeVisitor;
 import org.opensearch.sql.ast.Node;
 import org.opensearch.sql.ast.expression.IntervalUnit;
 import org.opensearch.sql.ast.expression.SpanUnit;
+import org.opensearch.sql.ast.expression.UnresolvedExpression;
 import org.opensearch.sql.ast.expression.WindowBound;
 import org.opensearch.sql.ast.expression.WindowFrame;
 import org.opensearch.sql.ast.tree.Relation;
@@ -163,9 +164,54 @@ public interface PlanUtils {
     }
   }
 
+  /**
+   * Translates a list of (SortOption, UnresolvedExpression) pairs into Calcite RexNodes suitable
+   * for use as window function ORDER BY keys, applying DESC and NULL FIRST/LAST directives via
+   * RelBuilder.
+   */
+  static List<RexNode> translateOrderKeys(
+      List<
+              org.apache.commons.lang3.tuple.Pair<
+                  org.opensearch.sql.ast.tree.Sort.SortOption, UnresolvedExpression>>
+          sortList,
+      java.util.function.Function<UnresolvedExpression, RexNode> analyzer,
+      CalcitePlanContext context) {
+    return sortList.stream()
+        .map(
+            pair -> {
+              RexNode sortField = analyzer.apply(pair.getRight());
+              if (pair.getLeft().getSortOrder()
+                  == org.opensearch.sql.ast.tree.Sort.SortOrder.DESC) {
+                sortField = context.relBuilder.desc(sortField);
+              }
+              if (pair.getLeft().getNullOrder()
+                  == org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_LAST) {
+                sortField = context.relBuilder.nullsLast(sortField);
+              } else if (pair.getLeft().getNullOrder()
+                  == org.opensearch.sql.ast.tree.Sort.NullOrder.NULL_FIRST) {
+                sortField = context.relBuilder.nullsFirst(sortField);
+              }
+              return sortField;
+            })
+        .toList();
+  }
+
   static RexNode makeOver(
       CalcitePlanContext context,
       BuiltinFunctionName functionName,
+      RexNode field,
+      List<RexNode> argList,
+      List<RexNode> partitions,
+      List<RexNode> orderKeys,
+      @Nullable WindowFrame windowFrame) {
+    return makeOver(
+        context, functionName, false, field, argList, partitions, orderKeys, windowFrame);
+  }
+
+  static RexNode makeOver(
+      CalcitePlanContext context,
+      BuiltinFunctionName functionName,
+      boolean distinct,
       RexNode field,
       List<RexNode> argList,
       List<RexNode> partitions,
@@ -216,6 +262,22 @@ public interface PlanUtils {
             true,
             lowerBound,
             upperBound);
+      case RANK:
+        return withOver(
+            context.relBuilder.aggregateCall(SqlStdOperatorTable.RANK),
+            partitions,
+            orderKeys,
+            true,
+            lowerBound,
+            upperBound);
+      case DENSE_RANK:
+        return withOver(
+            context.relBuilder.aggregateCall(SqlStdOperatorTable.DENSE_RANK),
+            partitions,
+            orderKeys,
+            true,
+            lowerBound,
+            upperBound);
       case NTH_VALUE:
         return withOver(
             context.relBuilder.aggregateCall(SqlStdOperatorTable.NTH_VALUE, field, argList.get(0)),
@@ -226,7 +288,7 @@ public interface PlanUtils {
             upperBound);
       default:
         return withOver(
-            makeAggCall(context, functionName, false, field, argList),
+            makeAggCall(context, functionName, distinct, field, argList),
             partitions,
             orderKeys,
             rows,

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -425,6 +425,9 @@ public enum BuiltinFunctionName {
           .put("dc", BuiltinFunctionName.DISTINCT_COUNT_APPROX)
           .put("distinct_count", BuiltinFunctionName.DISTINCT_COUNT_APPROX)
           .put("pattern", BuiltinFunctionName.INTERNAL_PATTERN)
+          .put("row_number", BuiltinFunctionName.ROW_NUMBER)
+          .put("rank", BuiltinFunctionName.RANK)
+          .put("dense_rank", BuiltinFunctionName.DENSE_RANK)
           .build();
 
   public static Optional<BuiltinFunctionName> of(String str) {
@@ -439,6 +442,17 @@ public enum BuiltinFunctionName {
   public static Optional<BuiltinFunctionName> ofWindowFunction(String functionName) {
     return Optional.ofNullable(
         WINDOW_FUNC_MAPPING.getOrDefault(functionName.toLowerCase(Locale.ROOT), null));
+  }
+
+  /**
+   * Pure window functions (no aggregate semantics, take no field argument). They are not registered
+   * in the aggregate function registry, so callers must skip aggregate validation.
+   */
+  private static final Set<BuiltinFunctionName> PURE_WINDOW_FUNCTIONS =
+      Set.of(ROW_NUMBER, RANK, DENSE_RANK);
+
+  public static boolean isPureWindowFunction(BuiltinFunctionName functionName) {
+    return PURE_WINDOW_FUNCTIONS.contains(functionName);
   }
 
   public static final Set<BuiltinFunctionName> COMPARATORS =


### PR DESCRIPTION
Fix four CalciteRelNodeVisitor/RexNodeVisitor gaps surfaced when routing the V2 SQL AST through the unified query path:

- Add Alias case in project expansion: SQL `SELECT COUNT(*) AS cnt ... GROUP BY ...` previously crashed with "Unexpected expression type: Alias". Reference already-computed aggregates by schema name instead of re-analyzing.
- Add visitLimit override for SQL LIMIT/OFFSET. PPL is unaffected (uses the Head node).
- Fix bucketNullable NPE when SQL GROUP BY produces an Aggregation without BUCKET_NULLABLE arg. Use `getOrDefault(..., Literal.TRUE)` to match Analyzer.java.
- Rewrite visitWindowFunction to handle AggregateFunction (V2 SQL) + DISTINCT + OVER ORDER BY (previously hardcoded to List.of()). Register ROW_NUMBER/RANK/DENSE_RANK in WINDOW_FUNC_MAPPING and bypass aggregate validation for these pure window functions. Add a makeOver overload with a distinct parameter (old signature delegates with false to preserve PPL behavior).

Add seven tests in UnifiedQueryPlannerSqlTest, one per fix. Verified zero PPL regressions across 2300+ existing tests.

### Description
[Describe what this change achieves]

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff` or `-s`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
